### PR TITLE
Move import statements in CSS to top

### DIFF
--- a/src/css/code/workspace.css
+++ b/src/css/code/workspace.css
@@ -1,3 +1,5 @@
+@import "./workspace-item.css";
+
 #workspace {
   --color-workspace-gutter: var(--u-color_container_subdued);
 
@@ -78,5 +80,3 @@
     width: auto;
   }
 }
-
-@import "./workspace-item.css";

--- a/src/css/ui.css
+++ b/src/css/ui.css
@@ -1,3 +1,10 @@
+@import "./ui/colors.css";
+@import "./ui/fonts.css";
+@import "./ui/base.css";
+@import "./ui/animations.css";
+@import "./ui/components.css";
+@import "./ui/page-layout.css";
+
 :root {
   --size-base: 16px;
   --app-header-height: 3.5rem;
@@ -96,10 +103,3 @@
     display: inherit;
   }
 }
-
-@import "./ui/colors.css";
-@import "./ui/fonts.css";
-@import "./ui/base.css";
-@import "./ui/animations.css";
-@import "./ui/components.css";
-@import "./ui/page-layout.css";


### PR DESCRIPTION
While making a storybook project for UI-Core, I found that `@import` at the bottom of CSS files triggers Vite errors.
Because of these warnings, CSS is not applied to elements. After moving these `@import` statements to the top of files, CSS is applied.

According to CSS reference, it seems that `@import`s need to be put at the top of files.
> An `@import` rule must be defined at the top of stylesheet, before any other at-rule (except [@charset](https://developer.mozilla.org/en-US/docs/Web/CSS/@charset) and [@layer](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer)) and style declaration, else it will be ignored.

From https://developer.mozilla.org/en-US/docs/Web/CSS/@import


I'm not sure if this change affects other UI parts or not. However, if this doesn't trigger any layout issues, I think this change is good for handling CSS properly.


### Vite errors
```
[vite:css] @import must precede all other statements (besides @charset or empty @layer)
94 |  @media only screen and (--u-viewport_max-sm) {
95 |    .max-sm {
96 |      display: inherit;
   |                 ^
97 |    }
98 |  }
[vite:css] @import must precede all other statements (besides @charset or empty @layer)
98 |  }
99 |  
100|  @import "./ui/colors.css";
   |               ^
101|  @import "./ui/fonts.css";
102|  @import "./ui/base.css";
[vite:css] @import must precede all other statements (besides @charset or empty @layer)
99 |  
100|  @import "./ui/colors.css";
101|  @import "./ui/fonts.css";
   |              ^
102|  @import "./ui/base.css";
103|  @import "./ui/animations.css";
[vite:css] @import must precede all other statements (besides @charset or empty @layer)
100|  @import "./ui/colors.css";
101|  @import "./ui/fonts.css";
102|  @import "./ui/base.css";
   |             ^
103|  @import "./ui/animations.css";
104|  @import "./ui/components.css";
[vite:css] @import must precede all other statements (besides @charset or empty @layer)
101|  @import "./ui/fonts.css";
102|  @import "./ui/base.css";
103|  @import "./ui/animations.css";
   |                   ^
104|  @import "./ui/components.css";
105|  @import "./ui/page-layout.css";
[vite:css] @import must precede all other statements (besides @charset or empty @layer)
102|  @import "./ui/base.css";
103|  @import "./ui/animations.css";
104|  @import "./ui/components.css";
   |                   ^
105|  @import "./ui/page-layout.css";
106|  
[vite:css] @import must precede all other statements (besides @charset or empty @layer)
8  |  @import "./code/hashvatar.css";
9  |  @import "./code/empty-state.css";
10 |  
   |   ^
```