### PR TITLE
Fix gray color variable

### DIFF
--- a/src/css/ui/components/anchored-overlay.css
+++ b/src/css/ui/components/anchored-overlay.css
@@ -21,7 +21,7 @@
   --c-color_form-field_focus-outline: var(--u-color_focus-outline);
   --c-color_form-field_icon_subdued: var(--u-color_icon_subdued);
   --c-color_form-field_background: var(--color-gray-darken-20);
-  --c-color_form-field_background_hovered: var(--gray-darken-10);
+  --c-color_form-field_background_hovered: var(--color-gray-darken-10);
 }
 
 .anchored-overlay_sheet {


### PR DESCRIPTION
It seems that CSS variable name was inappropriate.

`--gray-darken-10` -> `--color-gray-darken-10`

`check-css-vars` catch this bug and triggers error in CI in another PR.

```sh
❯❯❯ npm run check-css-vars

> check-css-vars
> scripts/check-css-vars.mjs

🚨 Error! 1 undefined CSS variables used:

--gray-darken-10
```