### PR TITLE
Update HTTP timeout to 30s

### DIFF
--- a/src/Lib/HttpApi.elm
+++ b/src/Lib/HttpApi.elm
@@ -396,4 +396,4 @@ httpJsonBodyResolver decoder resp =
 
 timeout : Float
 timeout =
-    15000
+    30000


### PR DESCRIPTION
15s is already a bad experience, but its probably worse to have it show a timeout error instead of waiting a little longer for a potential successful response however bad that might be.