### PR TITLE
Fixing minimap overlap issue (#76)

### DIFF
--- a/src/css/ui/components/action-menu.css
+++ b/src/css/ui/components/action-menu.css
@@ -26,7 +26,11 @@
   gap: 0;
   padding: 0.375rem;
   animation: slide-down 0.2s var(--anim-elastic);
-  z-index: var(--layer-popover);
+  /* 
+    It must be greater than `workspace-minimap` z-index value. 
+    Incrementing by 1 fixes issue #76.
+  */
+  z-index: calc(var(--layer-tooltip) + 1);
   overflow: hidden;
 }
 


### PR DESCRIPTION
After the fix it would look normal again:

![shot-2024-01-25-at-17-14-57--area](https://github.com/unisonweb/ui-core/assets/472885/bad42ab3-0767-45e5-82a0-e6aa48af1414)

- Fixes #76 