### PR TITLE
Minimap scrollable

### DIFF
--- a/src/css/code/workspace.css
+++ b/src/css/code/workspace.css
@@ -59,8 +59,7 @@
   z-index: var(--layer-tooltip);
   right: 1rem;
   margin-top: -0.5rem;
-  top: 0.5rem;
-  max-height: 90%;
+  max-height: 75%;
   overflow: auto;
 }
 

--- a/src/css/code/workspace.css
+++ b/src/css/code/workspace.css
@@ -59,6 +59,9 @@
   z-index: var(--layer-tooltip);
   right: 1rem;
   margin-top: -0.5rem;
+  top: 0.5rem;
+  max-height: 90%;
+  overflow: auto;
 }
 
 @media only screen and (--u-viewport_max-lg) {

--- a/storybook/.storybook/preview-head.html
+++ b/storybook/.storybook/preview-head.html
@@ -1,0 +1,8 @@
+<style>
+    html,
+    body,
+    #storybook-root {
+        height: 100%;
+        overflow: auto;
+    }
+</style>


### PR DESCRIPTION
I've updated CSS so that minimap area is scrollable in itself (rather than exceeding the screen).

I tried multiple ways, but couldn't manage CSS to make the header ("Map ...  Close All" part) sticky in the minimap area. Do you have any good solutions?