### PR TITLE
Fix long line overflow

### DIFF
--- a/src/css/code/workspace.css
+++ b/src/css/code/workspace.css
@@ -8,7 +8,6 @@
 }
 
 #workspace.view-mode_regular #workspace-content {
-  max-width: 100vw;
   /*overflow-x: hidden;*/
   display: flex;
   flex-direction: column;

--- a/src/css/ui/page-layout.css
+++ b/src/css/ui/page-layout.css
@@ -186,6 +186,7 @@
   flex: 1;
   flex-direction: column;
   gap: 1.5rem;
+  min-width: 0;
 }
 
 .page.centered-layout .page-content {

--- a/storybook/static/long.json
+++ b/storybook/static/long.json
@@ -1,0 +1,81 @@
+{
+  "missingDefinitions": [],
+  "termDefinitions": {
+    "#3tgadjo2kff3r8b0sfitdumiak0aoqkpkj87ueh41fudv2d079ek89bq7qog7dij99f7aqhug1271j5h5vuuf6ohk2u2m6eg374g6ag": {
+      "bestTermName": "assets.indexHtml",
+      "defnTermTag": "Plain",
+      "signature": [
+        {
+          "annotation": {
+            "contents": "##Text",
+            "tag": "TypeReference"
+          },
+          "segment": "Text"
+        }
+      ],
+      "termDefinition": {
+        "contents": [
+          {
+            "annotation": {
+              "contents": "assets.indexHtml",
+              "tag": "HashQualifier"
+            },
+            "segment": "assets.indexHtml"
+          },
+          {
+            "annotation": {
+              "tag": "TypeAscriptionColon"
+            },
+            "segment": " :"
+          },
+          {
+            "annotation": null,
+            "segment": " "
+          },
+          {
+            "annotation": {
+              "contents": "##Text",
+              "tag": "TypeReference"
+            },
+            "segment": "Text"
+          },
+          {
+            "annotation": null,
+            "segment": "\n"
+          },
+          {
+            "annotation": {
+              "contents": "assets.indexHtml",
+              "tag": "HashQualifier"
+            },
+            "segment": "assets.indexHtml"
+          },
+          {
+            "annotation": {
+              "tag": "BindingEquals"
+            },
+            "segment": " ="
+          },
+          {
+            "annotation": null,
+            "segment": "\n"
+          },
+          {
+            "annotation": null,
+            "segment": "  "
+          },
+          {
+            "annotation": {
+              "tag": "TextLiteral"
+            },
+            "segment": "\"<!DOCTYPE html>\\n  <html lang=\\\"en\\\">\\n  <head>\\n      <meta charset=\\\"UTF-8\\\">\\n      <meta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1.0\\\">\\n      <title>Unison Doodles</title>\\n      <link rel=\\\"stylesheet\\\" href=\\\"styles.css\\\">\\n  </head>\\n  <body>\\n    <div class=\\\"container\\\">\\n      <div class =\\\"row bg-primary text-white text-center py-5\\\">\\n        <h1 class=\\\"display-1\\\">🎨</h1>\\n        <h1 class=\\\"display-4 fw-bold\\\">Unison Doodles</h1>\\n        <p class=\\\"lead\\\">This test app was written with the Unison Cloud</p>\\n      </div>\\n\\n      <div class=\\\"row\\\">\\n        <div class=\\\"col pt-5\\\">\\n          <h2>🧑\\8205🎨 Draw something</h2>\\n        </div>\\n      </div>\\n\\n      <div class=\\\"row row-cols-2 g-1\\\">\\n\\n        <div class=\\\"col col-sm pt-2\\\">\\n          <canvas id =\\\"doodle-canvas-primary\\\" class=\\\"workspace doodle-canvas\\\"></canvas>\\n          <div id=\\\"canvas-palette\\\" class=\\\"palette\\\">\\n            <div class=\\\"inkwell p-2\\\" data-color=\\\"black\\\"></div>\\n            <div class=\\\"inkwell p-2\\\" data-color=\\\"red\\\"></div>\\n            <div class=\\\"inkwell p-2\\\" data-color=\\\"orange\\\"></div>\\n            <div class=\\\"inkwell p-2\\\" data-color=\\\"yellow\\\"></div>\\n            <div class=\\\"inkwell p-2\\\" data-color=\\\"green\\\"></div>\\n            <div class=\\\"inkwell p-2\\\" data-color=\\\"blue\\\"></div>\\n            <div class=\\\"inkwell p-2\\\" data-color=\\\"purple\\\"></div>\\n          </div>\\n        </div>\\n\\n        <div class=\\\"col col-sm px-3\\\">\\n          <form id=\\\"doodle-form\\\" onsubmit=\\\"return false\\\">\\n            <div class=\\\"form-group pb-3\\\">\\n              <label for =\\\"title\\\">Title</label>\\n              <input type=\\\"text\\\" class=\\\"form-control\\\" id=\\\"title\\\" name=\\\"title\\\" placeholder=\\\"Enter title\\\">\\n              <small id=\\\"titleHelp\\\" class=\\\"form-text text-muted\\\">Give your drawing a title</small>\\n            </div>\\n            <div class=\\\"form-group pb-3\\\">\\n              <label for=\\\"author\\\">Author</label>\\n              <input type=\\\"text\\\" class=\\\"form-control\\\" id=\\\"author\\\" name=\\\"author\\\" placeholder=\\\"Enter name\\\">\\n              <small id=\\\"authorHelp\\\" class=\\\"form-text text-muted\\\">Who made this work of art?</small>\\n              <div class=\\\"button-group py-3\\\">\\n                <button id=\\\"save-doodle\\\" type=\\\"submit\\\" class=\\\"btn btn-info\\\">Save</button>\\n                <button id=\\\"clear-doodle\\\" type=\\\"reset\\\" class=\\\"btn btn-warning\\\">Clear</button>\\n              </div>\\n            </div>\\n          </form>\\n        </div>\\n\\n      </div>\\n\\n    <div class=\\\"container pt-5\\\">\\n      <div id=\\\"doodle-log-holder\\\" class=\\\"row row-cols-1\\\">\\n            <h2>🖼 Gallery</h2>\\n            <h3>Everyone's work is here for now!</h3>\\n            <div class=\\\"album py-5 px-5 bg-light\\\">\\n              <div id=\\\"doodle-log\\\" class=\\\"row row-cols-1 row-cols-sm-2 row-cols-md-3 g-3\\\"></div>\\n            </div>\\n      </div>\\n    </div>\\n    <script src=\\\"./script.js\\\"></script>\\n    <link href=\\\"https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css\\\" rel=\\\"stylesheet\\\" integrity=\\\"sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC\\\" crossorigin=\\\"anonymous\\\">\\n    </div>\\n  </body>\\n</html>\""
+          }
+        ],
+        "tag": "UserObject"
+      },
+      "termDocs": [],
+      "termNames": ["assets.indexHtml"]
+    }
+  },
+  "typeDefinitions": {}
+}

--- a/storybook/stories/Stories/Code/WorkspaceItem.elm
+++ b/storybook/stories/Stories/Code/WorkspaceItem.elm
@@ -35,7 +35,7 @@ init : () -> ( Model, Cmd Message )
 init _ =
     ( { workspaceItem = Nothing }
     , Http.get
-        { url = "/long.json"
+        { url = "/increment_term_def.json"
         , expect = Http.expectJson GotItem (decodeItem sampleReference)
         }
     )

--- a/storybook/stories/Stories/Code/WorkspaceItem.elm
+++ b/storybook/stories/Stories/Code/WorkspaceItem.elm
@@ -35,7 +35,7 @@ init : () -> ( Model, Cmd Message )
 init _ =
     ( { workspaceItem = Nothing }
     , Http.get
-        { url = "/increment_term_def.json"
+        { url = "/long.json"
         , expect = Http.expectJson GotItem (decodeItem sampleReference)
         }
     )

--- a/storybook/stories/Stories/Code/code.stories.js
+++ b/storybook/stories/Stories/Code/code.stories.js
@@ -4,6 +4,7 @@ import { initElmStory } from "../../initElmStory.js";
 import WorkspaceItem from "./WorkspaceItem.elm";
 import Workspace from "./Workspace.elm";
 import WorkspaceMinimap from "./WorkspaceMinimap.elm";
+import PageContent from "./PageContent.elm";
 
 export const workspace = () => {
   return initElmStory(Workspace.Elm.Stories.Code.Workspace);
@@ -15,4 +16,8 @@ export const workspaceItem = () => {
 
 export const workspaceMinimap = () => {
   return initElmStory(WorkspaceMinimap.Elm.Stories.Code.WorkspaceMinimap);
+};
+
+export const pageContent = () => {
+  return initElmStory(PageContent.Elm.Stories.Code.PageContent);
 };


### PR DESCRIPTION
Removing `max-width: 100vw;` from `#workspace.view-mode_regular #workspace-content`, then adding `min-width: 0;` to `.page-content .columns .column` seems to fix the undesired behavior of overflowing long lines.

However, the entire code area width becomes the width of `--readable-column-width-medium`.
Is this the desired behavior?

<img width="1280" alt="Screenshot 2024-03-28 at 17 27 17" src="https://github.com/unisonweb/ui-core/assets/3376690/675c2d1c-fca9-4cf2-8d70-e66f6a28b4bc">


### Reasoning
The source of issue seems to be:
- `max-width: 100vw;` of `#workspace-content` seems inherently unnecessary. (so should be removed)
- `.columns` has `flex-direction:row`
- `.column`, the child of `.columns`, extends beyond its parent (`.columns`)

This situation is similar to these known issues:
- https://stackoverflow.com/questions/63601481/flex-child-is-overflowing-the-parent-container-even-after-setting-min-width0
- https://www.bigbinary.com/blog/understanding-the-automatic-minimum-size-of-flex-items