### PR TITLE
feat: add id attribute to section header

### DIFF
--- a/src/Code/Definition/Doc.elm
+++ b/src/Code/Definition/Doc.elm
@@ -591,8 +591,10 @@ view syntaxConfig toggleFoldMsg docFoldToggles document =
                         level =
                             min 6 sectionLevel
 
+                        sectionSlug = title |> toString "-"
+
                         titleEl =
-                            Html.node ("h" ++ String.fromInt level) [] [ viewAtCurrentSectionLevel title ]
+                            Html.node ("h" ++ String.fromInt level) [ id sectionSlug ] [ viewAtCurrentSectionLevel title ]
                     in
                     section [] (titleEl :: List.map (viewSectionContent (view_ (sectionLevel + 1))) docs)
 


### PR DESCRIPTION
This is so we can link to headers in a Doc, resolving: https://github.com/unisonweb/ui-core/issues/93

I'm not sure what the UI should look like for a section that is linkable tho.