### PR TITLE
Switch to ryan-haskell/date-format to fix storybook build.

### DIFF
--- a/storybook/elm.json
+++ b/storybook/elm.json
@@ -29,7 +29,7 @@
             "mgold/elm-nonempty-list": "4.2.0",
             "noahzgordon/elm-color-extra": "1.0.2",
             "rtfeldman/elm-iso8601-date-strings": "1.1.4",
-            "ryannhg/date-format": "2.3.0",
+            "ryan-haskell/date-format": "1.0.0",
             "stoeffel/set-extra": "1.2.3",
             "wernerdegroot/listzipper": "4.0.0"
         },


### PR DESCRIPTION
A similar change has already been applied to the main elm.json file, and I also found similar changes in other (unrelated) codebases. Copying the version range from base elm.json didn't work (difference between libs in dependences vs dependencies/direct?), so pinned to an exact version instead.

I have no Elm experience, there may be a better way to solve this.