### PR TITLE
Remove extra newlines when copying code

### DIFF
--- a/src/css/ui/components/tooltip.css
+++ b/src/css/ui/components/tooltip.css
@@ -279,7 +279,7 @@ positioned absolute within the overflow container.
 /* -- Trigger / Showing -----------------------------------------------------*/
 
 .tooltip-trigger {
-  display: inline-flex;
+  display: inline-block;
 }
 
 .tooltip-trigger.tooltip_show > .tooltip,


### PR DESCRIPTION
Here is my selection:
<img width="760" height="489" alt="image" src="https://github.com/user-attachments/assets/28a698fc-3368-4f86-82a3-f59e7b977667" />

Without the changes in this PR, the text in the clipboard would be:
```
doc.div
 :
 Nat -> Nat ->
{
Exception
}
 Nat
doc.div a b =
  
use 
Nat
 
/
 
==

  
if
 b == 
0
 then
 
Exception.raise
 (failure 
"cannot divide by zero"
 b)
  
else
 a / b
 ```
 To many newlines, you think?
 
 So with the changes in this mr, the extra newlines go away and we get:
 ```
doc.div : Nat -> Nat ->{Exception} Nat
doc.div a b =
  use Nat / ==
  if b == 0 then Exception.raise (failure "cannot divide by zero" b)
  else a / b
 ```
 
 I'm aware that there is a button to copy the whole block, but sometimes you only want to select and copy a smaller section.